### PR TITLE
feat: Add automatic E2E test runs for pull requests

### DIFF
--- a/.github/workflows/CI-e2e-tests.yml
+++ b/.github/workflows/CI-e2e-tests.yml
@@ -1,6 +1,8 @@
 name: zkVerify E2E Tests
 
 on:
+  pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
     inputs:
       zkverify_docker_tag:
@@ -23,7 +25,7 @@ on:
         type: string
       debug_enabled:
         type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
         required: false
         default: false
 
@@ -75,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: HorizenLabs/zkVerify-qa
-          ref: main
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || 'main' }}
           clean: true
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN }}
@@ -85,20 +87,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
-      
+
       - name: Run E2E tests
         id: run-e2e-tests
         uses: ./.github/actions/e2e-test
         with:
-          zkverify_docker_tag: ${{ inputs.zkverify_docker_tag || github.event.inputs.docker_tag }}
+          zkverify_docker_tag: ${{ github.event_name == 'pull_request' && 'latest' || inputs.zkverify_docker_tag || github.event.inputs.docker_tag }}
           zkverify_version: ${{ inputs.zkverify_version || github.event.inputs.zkverify_version }}
-          attestation_bot_branch: ${{ inputs.attestation_bot_branch || github.event.inputs.attestation_bot_branch }}
-          zkv_contracts_branch: ${{ inputs.zkv_contracts_branch || github.event.inputs.zkv_contracts_branch }}
+          attestation_bot_branch: ${{ github.event_name == 'pull_request' && 'main' || inputs.attestation_bot_branch || github.event.inputs.attestation_bot_branch }}
+          zkv_contracts_branch: ${{ github.event_name == 'pull_request' && 'main' || inputs.zkv_contracts_branch || github.event.inputs.zkv_contracts_branch }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           QA_SLACK_WEBHOOK_URL: ${{ secrets.QA_SLACK_WEBHOOK_URL }}
-       
+
       - name: Print test status
         run: |
           if [ "${{ steps.run-e2e-tests.outputs.test_status }}" == "success" ]; then


### PR DESCRIPTION
Jira ticket: [[WEB3-1342] Attestation Bot: Run tests in CI](https://horizenlabs.atlassian.net/browse/WEB3-1342)

Add automatic E2E test runs for pull requests to improve our testing workflow and catch issues earlier in the development cycle.

## Changes
- Modified `.github/workflows/CI-e2e-tests.yml` to trigger on pull request events
- Updated checkout action to use PR branch when running from pull requests
- Set default branches for dependencies in PR context:
  - Uses 'latest' Docker tag for PR builds
  - Uses 'main' branch for attestation-bot and zkv-contracts in PR context
  - Maintains custom branch selection for manual runs
- Cleaned up workflow file formatting

## Features
- Automatic E2E test execution when PRs are opened or updated

**Note:** ⚠️ Tests are currently failing. This PR should be kept on hold and not merged until the test issues are resolved in a separate ticket.
